### PR TITLE
Move challenges to datagroup to handle SAN certs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 # Created by .ignore support plugin (hsz.mobi)
+accounts/*
+certs/*
+wellknown/*
+
 ### Python template
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,13 @@
-# Created by .ignore support plugin (hsz.mobi)
-accounts/*
-certs/*
-wellknown/*
+# project stuff
+!accounts/README.txt
+!certs/README.txt
+!wellknown/README.txt
+accounts/
+certs/
+wellknown/
 
+
+# Created by .ignore support plugin (hsz.mobi)
 ### Python template
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ than certificate management and should have its own workflow.
 
 ### [Tim Riker](https://rikers.org) added
 * run as non-root in a working directory
+* include full chain in .crt so no separate chain is needed
 * create SSL profiles if missing
 * create client-ssl profiles if missing
 * irule uses a datagroup to handle multiple challenges for multiple names in a certificate.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ than certificate management and should have its own workflow.
 ### [Tim Riker](https://rikers.org) added
 * run as non-root in a working directory
 * include full chain in .crt so no separate chain is needed
-* create SSL profiles if missing
+* create or update certs/keys
 * create client-ssl profiles if missing
 * irule uses a datagroup to handle multiple challenges for multiple names in a certificate.
 

--- a/accounts/README.txt
+++ b/accounts/README.txt
@@ -1,0 +1,1 @@
+# dehydrated accounts are stored here

--- a/certs/README.txt
+++ b/certs/README.txt
@@ -1,0 +1,1 @@
+# dehydrated certs are stored here

--- a/challenge.irule
+++ b/challenge.irule
@@ -1,6 +1,0 @@
-when HTTP_REQUEST {
-  log local0. "[HTTP::header User-Agent]"
-  if { ([HTTP::uri] eq "/.well-known/acme-challenge/TOKENFILE") && ([HTTP::header User-Agent] contains "Let's Encrypt validation server") } {
-    HTTP::respond 200 content TOKENVALUE
-  } else { HTTP::respond 404 content "not found" }
-}

--- a/config
+++ b/config
@@ -111,7 +111,6 @@ HOOK=${BASEDIR}/hook_script.py
 
 # E-mail to use during the registration (default: <unset>)
 #CONTACT_EMAIL=
-CONTACT_EMAIL="me@example.com"
 
 # Lockfile location, to prevent concurrent access (default: $BASEDIR/lock)
 #LOCKFILE="${BASEDIR}/lock"

--- a/config
+++ b/config
@@ -66,7 +66,7 @@ CHALLENGETYPE="http-01"
 
 # Output directory for challenge-tokens to be served by webserver or deployed in HOOK (default: /var/www/dehydrated)
 #WELLKNOWN="/var/www/dehydrated"
-WELLKNOWN="/etc/dehydrated/wellknowns"
+WELLKNOWN="wellknown"
 
 # Default keysize for private keys (default: 4096)
 #KEYSIZE="4096"
@@ -92,7 +92,7 @@ CURL_OPTS="--http1.1"
 # BASEDIR and WELLKNOWN variables are exported and can be used in an external program
 # default: <unset>
 #HOOK=
-HOOK=/etc/dehydrated/hook_script.py
+HOOK=${BASEDIR}/hook_script.py
 
 # Chain clean_challenge|deploy_challenge arguments together into one hook call per certificate (default: no)
 #HOOK_CHAIN="no"

--- a/hook_script.py
+++ b/hook_script.py
@@ -9,95 +9,97 @@ import sys
 
 requests.packages.urllib3.disable_warnings()
 
-
 def get_credentials():
     return {'host': os.getenv('F5_HOST'), 'user': os.getenv('F5_USER'), 'pass': os.getenv('F5_PASS')}
-
 
 def instantiate_bigip(credentials):
     return BIGIP(credentials.get('host'), credentials.get('user'), credentials.get('pass'))
 
-
-def alter_template(token_info):
-    with open('challenge.irule', 'r') as f2:
-        new_challenge = ''
-        for line in f2:
-            new_line = line.rstrip()
-            new_line = new_line.replace('TOKENFILE', token_info[0])
-            new_line = new_line.replace('TOKENVALUE', token_info[1])
-            new_challenge += f'{new_line}\n'
-    return new_challenge
-
-
 def deploy_challenge(args):
-    new_irule = alter_template(args[1:])
     br = instantiate_bigip(get_credentials())
-    if br.exist('/mgmt/tm/ltm/rule/le_challenge_rule'):
-        rule = br.load('/mgmt/tm/ltm/rule/le_challenge_rule')
-        rule.properties['apiAnonymous'] = new_irule
-        br.save(rule)
-        vip = br.load('/mgmt/tm/ltm/virtual/external_http_test')
-        if vip.properties.get('rules') is None:
-            vip.properties['rules'] = ['le_challenge_rule']
-        else:
-            vip.properties['rules'].append('le_challenge_rule')
-        br.save(vip)
-    else:
-        ltm_rule_object = {'name': 'le_challenge_rule', '': new_irule}
-        br.create('/mgmt/tm/ltm/rule', ltm_rule_object)
-        if br.exist('/mgmt/tm/ltm/rule/le_challenge_rule'):
-            vip = br.load('/mgmt/tm/ltm/virtual/external_http_test')
-            vip.properties['rules'].append('le_challenge_rule')
+    f = open('rule_le_challenge.iRule')
+    irule = f.read()
+    f.close()
+    if not br.exist('/mgmt/tm/ltm/rule/rule_le_challenge'):
+        rule = {'name': 'rule_le_challenge', 'apiAnonymous': irule}
+        br.create('/mgmt/tm/ltm/rule', rule)
+        logger.info(' + (hook) irule rule_le_challenge added.')
+    if not br.exist('/mgmt/tm/ltm/data-group/internal/dg_le_challenge'):
+        dg = {'name': 'dg_le_challenge', 'type': 'string', 'records': [{'name':'name','data':'data'}]}
+        br.create('/mgmt/tm/ltm/data-group/internal', dg)
+        logger.info(' + (hook) datagroup dg_le_challenge added.')
+    if br.exist('/mgmt/tm/ltm/rule/rule_le_challenge'):
+        vip = br.load(f'/mgmt/tm/ltm/virtual/{f5_http}')
+        if '/Common/rule_le_challenge' not in vip.properties['rules']:
+            if vip.properties.get('rules') is None:
+                vip.properties['rules'] = ['rule_le_challenge']
+            elif not '/mgmt/tm/ltm/rule/rule_le_challenge' in vip.properties['rules']:
+                vip.properties['rules'].insert(0,'rule_le_challenge')
             br.save(vip)
-    logger.info(' + (hook) Challenge rule added to virtual.')
-
+            logger.info(f' + (hook) Challenge rule added to virtual {f5_http}.')
+    dg = br.load('/mgmt/tm/ltm/data-group/internal/dg_le_challenge')
+    dg.properties['records'].append({'name':args[1],'data':args[2]})
+    br.save(dg)
+    logger.info(f' + (hook) Challenge added to datagroup dg_le_challenge for {args[0]}.')
 
 def invalid_challenge(args):
     logger.info(f' + (hook) Invalid Challenge Args: {args}')
-
+    sys.exit(-1)
 
 def clean_challenge(args):
     br = instantiate_bigip(get_credentials())
-    vip = br.load('/mgmt/tm/ltm/virtual/external_http_test')
-    vip.properties['rules'].remove('/Common/le_challenge_rule')
-    br.save(vip)
-    logger.info(' + (hook) Challenge rule removed from virtual.')
-
+    vip = br.load(f'/mgmt/tm/ltm/virtual/{f5_http}')
+    if '/Common/rule_le_challenge' in vip.properties['rules']:
+        vip.properties['rules'].remove('/Common/rule_le_challenge')
+        br.save(vip)
+        logger.info(f' + (hook) Challenge rule rule_le_challenge removed from virtual {f5_http}.')
+    if br.exist('/mgmt/tm/ltm/rule/rule_le_challenge'):
+        br.delete('/mgmt/tm/ltm/rule/rule_le_challenge')
+        logger.info(f' + (hook) irule rule_le_challenge removed.')
+    if br.exist('/mgmt/tm/ltm/data-group/internal/dg_le_challenge'):
+        br.delete('/mgmt/tm/ltm/data-group/internal/dg_le_challenge')
+        logger.info(' + (hook) datagroup dg_le_challenge removed.')
 
 def deploy_cert(args):
     br = instantiate_bigip(get_credentials())
     br.upload('/mgmt/shared/file-transfer/uploads', args[1])
-    br.upload('/mgmt/shared/file-transfer/uploads', args[2])
-    br.upload('/mgmt/shared/file-transfer/uploads', args[4])
-    key_status = br.exist(f'/mgmt/tm/sys/file/ssl-key/le_auto_{args[0]}.key')
-    cert_status = br.exist(f'/mgmt/tm/sys/file/ssl-cert/le_auto_{args[0]}.crt')
-    chain_status = br.exist(f'/mgmt/tm/sys/file/ssl-cert/le_auto_chain.crt')
+    br.upload('/mgmt/shared/file-transfer/uploads', args[3])
+    key_status = br.exist(f'/mgmt/tm/sys/file/ssl-key/auto_le_{args[0]}.key')
+    cert_status = br.exist(f'/mgmt/tm/sys/file/ssl-cert/auto_le_{args[0]}.crt')
 
-    if key_status and cert_status and chain_status:
+    if key_status and cert_status:
         with br as transaction:
-            modkey = br.load(f'/mgmt/tm/sys/file/ssl-key/le_auto_{args[0]}.key')
+            modkey = br.load(f'/mgmt/tm/sys/file/ssl-key/auto_le_{args[0]}.key')
             modkey.properties['sourcePath'] = f'file:/var/config/rest/downloads/{args[1].split("/")[-1]}'
             br.save(modkey)
-            modcert = br.load(f'/mgmt/tm/sys/file/ssl-cert/le_auto_{args[0]}.crt')
-            modcert.properties['sourcePath'] = f'file:/var/config/rest/downloads/{args[2].split("/")[-1]}'
+            modcert = br.load(f'/mgmt/tm/sys/file/ssl-cert/auto_le_{args[0]}.crt')
+            modcert.properties['sourcePath'] = f'file:/var/config/rest/downloads/{args[3].split("/")[-1]}'
             br.save(modcert)
-            modchain = br.load(f'/mgmt/tm/sys/file/ssl-cert/le_auto_chain.crt')
-            modchain.properties['sourcePath'] = f'file:/var/config/rest/downloads/{args[4].split("/")[-1]}'
-            br.save(modchain)
-            logger.info(' + (hook) Existing Cert/Key updated in transaction.')
+            logger.info(f' + (hook) Cert/Key {args[0]} updated in transaction.')
     else:
-        keydata = {'name': f'le_auto_{args[0]}.key', 'sourcePath': f'file:/var/config/rest/downloads/{args[1].split("/")[-1]}'}
-        certdata = {'name': f'le_auto_{args[0]}.crt', 'sourcePath': f'file:/var/config/rest/downloads/{args[2].split("/")[-1]}'}
-        chaindata = {'name': f'le_auto_chain.crt', 'sourcePath': f'file:/var/config/rest/downloads/{args[4].split("/")[-1]}'}
+        keydata = {'name': f'auto_le_{args[0]}.key', 'sourcePath': f'file:/var/config/rest/downloads/{args[1].split("/")[-1]}'}
+        certdata = {'name': f'auto_le_{args[0]}.crt', 'sourcePath': f'file:/var/config/rest/downloads/{args[3].split("/")[-1]}'}
         br.create('/mgmt/tm/sys/file/ssl-key', keydata)
         br.create('/mgmt/tm/sys/file/ssl-cert', certdata)
-        br.create('/mgmt/tm/sys/file/ssl-cert', chaindata)
-        logger.info(' + (hook) New Certificate/Key/Chain created.')
-
+        logger.info(f' + (hook) Cert/Key {args[0]} created.')
+    if not br.exist(f'/mgmt/tm/ltm/profile/client-ssl/auto_le_{args[0]}'):
+        sslprof = {
+            'name' : f'auto_le_{args[0]}',
+            'defaultsFrom': '/Common/clientssl',
+            'certKeyChain': [{
+                'name': f'{args[0]}_0',
+                'cert': f'/Common/auto_le_{args[0]}.crt',
+                'key': f'/Common/auto_le_{args[0]}.key'
+            }]
+        }
+        logger.info(sslprof)
+        br.create('/mgmt/tm/ltm/profile/client-ssl', sslprof)
+        logger.info(f' + (hook) client-ssl profile created auto_le_{args[0]}.')
+    #profiles = br.load(f'/mgmt/tm/ltm/virtual/{f5_https}/profiles')
+    #logger.info(profiles)
 
 def unchanged_cert(args):
     logger.info(f' + (hook) No changes necessary.')
-
 
 if __name__ == '__main__':
     # Logging
@@ -105,22 +107,26 @@ if __name__ == '__main__':
     logger.addHandler(logging.StreamHandler())
     logger.setLevel(logging.INFO)
 
+    # get virtualserver names from environment
+    f5_http = os.getenv('F5_HTTP')
+    f5_https = os.getenv('F5_HTTPS')
+
     if len(sys.argv) > 2:
         hook = sys.argv[1]
     else:
         hook = ''
     if hook == 'deploy_challenge':
-        logger.info(' + (hook) Deploying Challenge')
+        logger.info(f' + (hook) Deploying Challenge {sys.argv[2]}')
         deploy_challenge(sys.argv[2:])
     elif hook == 'invalid_challenge':
-        logger.info(' + (hook) Invalid Challenge')
+        logger.info(f' + (hook) Invalid Challenge {sys.argv[2]}')
         invalid_challenge(sys.argv[2:])
     elif hook == 'clean_challenge':
-        logger.info(' + (hook) Cleaning Challenge')
+        logger.info(f' + (hook) Cleaning Challenge {sys.argv[2]}')
         clean_challenge(sys.argv[2:])
     elif hook == 'deploy_cert':
-        logger.info(' + (hook) Deploying Certs')
+        logger.info(f' + (hook) Deploying Certs {sys.argv[2]}')
         deploy_cert(sys.argv[2:])
     elif hook == 'unchanged_cert':
-        logger.info(' + (hook) Unchanged Certs')
+        logger.info(f' + (hook) Unchanged Certs {sys.argv[2]}')
         unchanged_cert(sys.argv[2:])

--- a/rule_le_challenge.iRule
+++ b/rule_le_challenge.iRule
@@ -1,0 +1,17 @@
+# look up Let's Encrypt validation requests in dg_le_challenge and return if found
+# pass through if not found in dg
+# Tim Riker <Tim@Rikers.org>
+
+when HTTP_REQUEST {
+    if { [class exists dg_le_challenge] } {
+        if {"[HTTP::uri]" starts_with "/.well-known/acme-challenge/"} {
+            set log(lekey) [getfield "[HTTP::uri]" "/" 4]
+            set log(levalue) [class match -value -- $log(lekey) equals dg_le_challenge]
+            if { $log(levalue) ne "" } {
+                HTTP::respond 200 content "$log(levalue)\n" "Content-Type" "text/plain" "Connection" "close"
+                event disable
+                return
+            }
+        }
+    }
+}

--- a/wellknown/README.txt
+++ b/wellknown/README.txt
@@ -1,0 +1,1 @@
+# dehydrated challenges are stored here


### PR DESCRIPTION
Moved to non-root, so create accounts, certs, and wellknown under working dir.
removed CONTACT_EMAIL, which user will need to add anyway
create client-ssl cert
updated docs, added Getting Started, etc.