### PR TITLE
Move env variables to config files for multiple cert processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Finally, it still utilizes F5's iControl REST interface to upload and configure 
 out the mostly-retired [f5-sdk](https://github.com/f5networks/f5-common-python) library for the
 [bigrest](https://github.com/leonardobdes/BIGREST) library.
 
-Removed from this project altogether is the creation of client SSL profiles, as that is a separate function
+**(Overridden by Tim Riker) Removed from this project altogether is the creation of client SSL profiles, as that is a separate function
 than certificate management and should have its own workflow.
 
 ### [Tim Riker](https://rikers.org) added
@@ -20,6 +20,16 @@ than certificate management and should have its own workflow.
 * create or update certs/keys
 * create client-ssl profiles if missing
 * irule uses a datagroup to handle multiple challenges for multiple names in a certificate.
+
+## [Scott Campbell](https://github.com/ScottECampbell) September 2023
+
+* Moved all environmental variables to configuration files so that this script can be used on multiple domains/certificates on the same run of dehydrated.
+* Added ".f5creds" JSON file which gives the host, user and password for LB access.  The user defined MUST be a LB Administrator otherwise the REST API will not function properly.
+* Added "virtual_servers" JSON file which maps the SSL certificate domains to their LB Virtual Server names since they do not always match **HTTP version of VS if available.
+* Added logic for SAN certs where both domains need verification and irule will be attached (and attempted deletion) on both domains.
+* Added variable to hook_script.py for SSL Client Parent Profile used for new SSL profiles with all desired settings included.
+* Fixed logic bug that would break processing if met with VS with no existing irules on LB.
+* Created bash script "cron_wrapper" so that process can be run from cron or command line and includes activation of correct python virtual environment (if required).
 
 ## Getting Started
 
@@ -39,6 +49,9 @@ register with dehydrated
 ```bash
 $ dehydrated -f config --register --accept-terms
 ```
+
+Edit virtual_servers file to include domain x Virtual Server mapping
+
 Add your domains and aliases to domains.txt and try a request
 ```bash
 $ dehydrated -f config -c --force --force-validation
@@ -49,17 +62,18 @@ $ dehydrated -f config -c --force --force-validation
 ```bash
 config # Dehydrated configuration file (edit CONTACT_EMAIL)
 domains.txt # Domains to sign and generate certs for (add names and aliases)
+virtual_servers # Domains x Virtual Servers mapping on F5 Loadbalancer
 dehydrated # acme client (install)
 bigrest # install python library
 rule_le_challenge.iRule # iRule configured and deployed to BIG-IP by the hook script
 hook_script.py # Python script called by dehydrated for special steps in the cert generation process
 
-# Environment Variables
-export F5_HOST=f.q.d.n
-export F5_USER=admin
-export F5_PASS=admin
-export F5_HTTP=vs_vip-name_HTTP
-export F5_HTTPS=vs_vip-name_HTTPS
+# Environment Variables (credentials moved to .f5creds file, vs_vip listings moved to virtual_servers file - S Campbell)
+#export F5_HOST=f.q.d.n
+#export F5_USER=admin
+#export F5_PASS=admin
+#export F5_HTTP=vs_vip-name_HTTP
+#export F5_HTTPS=vs_vip-name_HTTPS
 ```
 ## Usage
 
@@ -70,7 +84,9 @@ $ dehydrated -f config -c --force --force-validation
 
 ### Otherwise
 ```bash
-$ dehydrated -f config -c
+$ dehydrated -f config -c -g
+or
+$ cron_wrapper
 ```
 
 ## Expected Output
@@ -117,6 +133,9 @@ Processing example.com
 ## Caveats
 I tested one use case for a standard domain. Let's Encrypt and dehydrated support far more
 than I tested, so you'll likely need to do additional development to support those.
+
+** S Campbell - added ability for multiple certificates including SAN certificates 
+** virtual_servers file needs an entry for EACH SAN. Could investigate "HOOK_CHAIN=yes" functionality in dehydrated and then change hook script to deal with all SANs at once.
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ Processing example.com
 I tested one use case for a standard domain. Let's Encrypt and dehydrated support far more
 than I tested, so you'll likely need to do additional development to support those.
 
-** S Campbell - added ability for multiple certificates including SAN certificates 
-** virtual_servers file needs an entry for EACH SAN. Could investigate "HOOK_CHAIN=yes" functionality in dehydrated and then change hook script to deal with all SANs at once.
+* S Campbell - added ability for multiple certificates including SAN certificates 
+* virtual_servers file needs an entry for EACH SAN. Could investigate "HOOK_CHAIN=yes" functionality in dehydrated and then change hook script to deal with all SANs at once.
 
 ## Contributors
 

--- a/cron_wrapper
+++ b/cron_wrapper
@@ -1,0 +1,6 @@
+#!/usr/bin/bash
+
+# only required if separate python environment needed - otherwise commands can be directly added to your crontab
+cd /home/f5le/lets-encrypt-python
+source /home/f5le/pythonvenv/python37/bin/activate
+./dehydrated -c -g 2>&1

--- a/virtual_servers
+++ b/virtual_servers
@@ -1,0 +1,6 @@
+{
+ "domain.name": "VirtualServerNameOnLB_HTTP_if_available",
+ "example.com": "VS_example.com_http",
+ "anotherexample.com": "VS_anotherexample.com_https",
+ "www.anotherexample.com": "VS_anotherexample.com_https"
+}


### PR DESCRIPTION
Hello Jason,

I've cleaned up my edits.  Two new files, one required, one example only.

I've moved all the env variables to files and added the ability to have it run for a multiple number of domains/certificates.  Currently it runs nightly and has a mixture of single domain certificates and SAN certificates without issues.

In my environment I needed a python virtual environment so I've provided an example cron_wrapper file.

Please let me know if anything is unclear or needs more explanation.

Scott Campbell